### PR TITLE
Add default timeout for Guzzle driver

### DIFF
--- a/src/Api/Driver/GuzzleDriver.php
+++ b/src/Api/Driver/GuzzleDriver.php
@@ -42,6 +42,7 @@ class GuzzleDriver implements ApiClientDriver
 			$httpResponse = $this->client->send($request, [
 				RequestOptions::HTTP_ERRORS => false,
 				RequestOptions::ALLOW_REDIRECTS => false,
+				RequestOptions::TIMEOUT => 20,
 			]);
 
 			$responseCode = new ResponseCode($httpResponse->getStatusCode());


### PR DESCRIPTION
Stejný jako CurlDriver...

V 2.x by mělo zůstat 20s kvůli payment/recurrent... je to potřeba i v eAPI 1.6?