### PR TITLE
Add merchantData to oneclick/init request

### DIFF
--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -150,7 +150,8 @@ class RequestFactory
 		string $orderId,
 		string $clientIp,
 		?Price $price = null,
-		?string $description = null
+		?string $description = null,
+		?string $merchantData = null
 	): InitOneClickPaymentRequest
 	{
 		return new InitOneClickPaymentRequest(
@@ -159,7 +160,8 @@ class RequestFactory
 			$orderId,
 			$clientIp,
 			$price,
-			$description
+			$description,
+			$merchantData
 		);
 	}
 

--- a/tests/unit/Call/OneClick/InitOneClickPaymentRequestTest.php
+++ b/tests/unit/Call/OneClick/InitOneClickPaymentRequestTest.php
@@ -12,6 +12,7 @@ use SlevomatCsobGateway\Call\PaymentStatus;
 use SlevomatCsobGateway\Call\ResultCode;
 use SlevomatCsobGateway\Currency;
 use SlevomatCsobGateway\Price;
+use function base64_encode;
 
 class InitOneClickPaymentRequestTest extends TestCase
 {
@@ -32,6 +33,7 @@ class InitOneClickPaymentRequestTest extends TestCase
 				'totalAmount' => 1789600,
 				'currency' => 'CZK',
 				'description' => 'Nákup na vasobchod.cz (Lenovo ThinkPad Edge E540, Doprava PPL)',
+				'merchantData' => base64_encode('some-base64-encoded-merchant-data'),
 			])
 			->willReturn(
 				new Response(ResponseCode::get(ResponseCode::S200_OK), [
@@ -49,7 +51,8 @@ class InitOneClickPaymentRequestTest extends TestCase
 			'5547',
 			'127.0.0.1',
 			new Price(1789600, Currency::get(Currency::CZK)),
-			'Nákup na vasobchod.cz (Lenovo ThinkPad Edge E540, Doprava PPL)'
+			'Nákup na vasobchod.cz (Lenovo ThinkPad Edge E540, Doprava PPL)',
+			'some-base64-encoded-merchant-data'
 		);
 
 		$paymentResponse = $initPaymentRequest->send($apiClient);

--- a/tests/unit/RequestFactoryTest.php
+++ b/tests/unit/RequestFactoryTest.php
@@ -116,7 +116,8 @@ class RequestFactoryTest extends TestCase
 			'5547123',
 			'127.0.0.1',
 			new Price(1789600, Currency::get(Currency::CZK)),
-			'Nákup na vasobchod.cz (Lenovo ThinkPad Edge E540, Doprava PPL)'
+			'Nákup na vasobchod.cz (Lenovo ThinkPad Edge E540, Doprava PPL)',
+			'some-base64-encoded-merchant-data'
 		);
 
 		self::assertTrue(true);


### PR DESCRIPTION
Ahoj, při implementaci úprav pro splnění nových požadavků od ČSOB jsem narazil na chybějící podporu pro pole `merchantData` na metodě `oneclick/init`, které dle dokumentace eAPI v1.8 obsahuje.
https://github.com/csob/paymentgateway/wiki/Metody-pro-OneClick#metoda-oneclickinit-