### PR TITLE
Fix HTTP method used to call "echo/customer" and maximum zip length in OrderAddress

### DIFF
--- a/src/AdditionalData/OrderAddress.php
+++ b/src/AdditionalData/OrderAddress.php
@@ -12,7 +12,7 @@ class OrderAddress implements Encodable
 {
 
 	public const ADDRESS_LENGTH_MAX = 50;
-	public const ZIP_LENGTH_MAX = 50;
+	public const ZIP_LENGTH_MAX = 16;
 
 	public function __construct(
 		private string $address1,

--- a/src/Call/EchoCustomerRequest.php
+++ b/src/Call/EchoCustomerRequest.php
@@ -16,7 +16,7 @@ class EchoCustomerRequest
 
 	public function send(ApiClient $apiClient): EchoCustomerResponse
 	{
-		$response = $apiClient->get(
+		$response = $apiClient->post(
 			'echo/customer',
 			[
 				'merchantId' => $this->merchantId,

--- a/tests/unit/Call/EchoCustomerRequestTest.php
+++ b/tests/unit/Call/EchoCustomerRequestTest.php
@@ -17,7 +17,7 @@ class EchoCustomerRequestTest extends TestCase
 			->disableOriginalConstructor()
 			->getMock();
 
-		$apiClient->expects(self::once())->method('get')
+		$apiClient->expects(self::once())->method('post')
 			->with('echo/customer', [
 				'merchantId' => '012345',
 				'customerId' => 'cust123@mail.com',


### PR DESCRIPTION
See: https://github.com/csob/paymentgateway/wiki/Basic-methods#echocustomer-method-
See: https://github.com/csob/paymentgateway/wiki/Purchase-metadata#orderaddress-data-